### PR TITLE
feat/#14: ✨ about-meページの実装

### DIFF
--- a/src/app/about-me/page.tsx
+++ b/src/app/about-me/page.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import AboutMeContent from '@/components/organisms/AboutMeContent'
+
+const AboutMePage: React.FC = () => {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-[#44475a] p-8">
+      <AboutMeContent />
+    </div>
+  )
+}
+
+export default AboutMePage

--- a/src/app/about-me/page.tsx
+++ b/src/app/about-me/page.tsx
@@ -1,11 +1,16 @@
+'use client'
+
 import React from 'react'
 import AboutMeContent from '@/components/organisms/AboutMeContent'
+import { EditorLayout } from '@/components/templates/EditorLayout'
 
 const AboutMePage: React.FC = () => {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-[#44475a] p-8">
-      <AboutMeContent />
-    </div>
+    <EditorLayout>
+      <div className="min-h-screen flex items-center justify-center bg-[#44475a] p-8">
+        <AboutMeContent />
+      </div>
+    </EditorLayout>
   )
 }
 

--- a/src/app/about-me/page.tsx
+++ b/src/app/about-me/page.tsx
@@ -1,14 +1,94 @@
 'use client'
 
-import React from 'react'
+import React, { useState } from 'react'
 import AboutMeContent from '@/components/organisms/AboutMeContent'
 import { EditorLayout } from '@/components/templates/EditorLayout'
+import { DirectoryTree } from '@/components/molecules/DirectoryTree'
+import { fileContents } from '@/utils/constants/files'
 
 const AboutMePage: React.FC = () => {
+  // 開いているファイルのパスを配列で管理
+  const [openFiles, setOpenFiles] = useState<string[]>(['/src/about-me/introduction.ts'])
+  const [currentFile, setCurrentFile] = useState('/src/about-me/introduction.ts')
+
+  const handleFileSelect = (path: string) => {
+    // 既に開いているファイルの場合は、そのファイルをアクティブにする
+    if (!openFiles.includes(path)) {
+      setOpenFiles([...openFiles, path])
+    }
+    setCurrentFile(path)
+  }
+
+  const handleCloseFile = (path: string) => {
+    const newOpenFiles = openFiles.filter(file => file !== path)
+    setOpenFiles(newOpenFiles)
+    // 閉じたファイルが現在のファイルだった場合、最後のファイルをアクティブにする
+    if (path === currentFile && newOpenFiles.length > 0) {
+      setCurrentFile(newOpenFiles[newOpenFiles.length - 1])
+    }
+  }
+
   return (
     <EditorLayout>
-      <div className="min-h-screen flex items-center justify-center bg-[#44475a] p-8">
-        <AboutMeContent />
+      <div className="min-h-[calc(100vh-48px)] w-full flex items-center justify-center bg-[#282a36]">
+        <div className="w-[1300px] h-[700px] bg-[#282a36] rounded-xl border border-[#6272a4]/30 shadow-2xl overflow-hidden backdrop-blur-sm">
+          {/* タイトルバー */}
+          <div className="h-10 bg-[#21222c] flex items-center px-4 gap-2 border-b border-[#44475a]">
+            <div className="flex items-center gap-2">
+              <div className="w-3 h-3 rounded-full bg-[#ff5555] hover:bg-[#ff6e6e] transition-colors" />
+              <div className="w-3 h-3 rounded-full bg-[#f1fa8c] hover:bg-[#f4fb9d] transition-colors" />
+              <div className="w-3 h-3 rounded-full bg-[#50fa7b] hover:bg-[#6dff93] transition-colors" />
+            </div>
+            <div className="flex-1 text-center text-[#6272a4] text-sm">
+              about-me - Ojoxux Editor
+            </div>
+          </div>
+
+          <div className="h-[calc(100%-2.5rem)] flex">
+            {/* Activity Bar */}
+            <div className="w-12 bg-[#21222c] flex flex-col items-center py-4 space-y-4">
+              <button className="w-8 h-8 flex items-center justify-center text-[#bd93f9] hover:text-[#ff79c6] transition-colors">
+                <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M3 6h18M3 12h18M3 18h18"
+                  />
+                </svg>
+              </button>
+              <button className="w-8 h-8 flex items-center justify-center text-[#f8f8f2] bg-[#44475a] rounded">
+                <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"
+                  />
+                </svg>
+              </button>
+            </div>
+
+            {/* Side Bar & Editor */}
+            <div className="flex-1 flex">
+              <DirectoryTree
+                currentFile={currentFile}
+                onFileSelect={handleFileSelect}
+                className="border-r border-[#44475a] w-[280px] flex-shrink-0"
+              />
+
+              <div className="flex-1 bg-[#282a36]">
+                <AboutMeContent
+                  currentFile={currentFile}
+                  openFiles={openFiles}
+                  fileContent={fileContents[currentFile]}
+                  onFileSelect={setCurrentFile}
+                  onCloseFile={handleCloseFile}
+                />
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
     </EditorLayout>
   )

--- a/src/components/atoms/Avatar/index.tsx
+++ b/src/components/atoms/Avatar/index.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import Image from 'next/image'
+import { AvatarProps } from './types'
+
+const Avatar: React.FC<AvatarProps> = ({ src, alt, size = 80 }) => {
+  return (
+    <Image
+      src={src}
+      alt={alt}
+      width={size}
+      height={size}
+      className="rounded-full"
+      style={{ border: '3px solid #6272a4' }}
+    />
+  )
+}
+
+export default Avatar

--- a/src/components/atoms/Avatar/types.ts
+++ b/src/components/atoms/Avatar/types.ts
@@ -1,0 +1,5 @@
+export interface AvatarProps {
+  src: string
+  alt: string
+  size?: number
+}

--- a/src/components/atoms/NavLink/index.tsx
+++ b/src/components/atoms/NavLink/index.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link'
 
 export const NavLink = ({ path, label, isActive }: NavLinkProps) => {
   const isContactMe = path === '/contact-me'
+  const isAboutMe = path === '/about-me'
 
   return (
     <Link
@@ -10,6 +11,7 @@ export const NavLink = ({ path, label, isActive }: NavLinkProps) => {
       className={`
         px-8 h-full flex items-center border-r border-[#44475a] 
         ${isContactMe ? 'border-l' : ''} 
+        ${isAboutMe ? 'border-l' : ''}
         hover:bg-[#44475a] transition-colors relative text-sm
         ${isActive ? 'text-[#ff79c6]' : 'text-gray-400'}
         ${isActive ? 'after:absolute after:bottom-0 after:left-0 after:w-full after:h-[2px] after:bg-[#ff79c6]' : ''}

--- a/src/components/molecules/AboutSection/index.tsx
+++ b/src/components/molecules/AboutSection/index.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import { AboutSectionProps } from './types'
+
+const AboutSection: React.FC<AboutSectionProps> = ({ title, children }) => {
+  return (
+    <section className="mb-8">
+      <h2 className="text-2xl font-semibold text-[#8be9fd] mb-2">{title}</h2>
+      <div className="text-base text-[#f8f8f2]">{children}</div>
+    </section>
+  )
+}
+
+export default AboutSection

--- a/src/components/molecules/AboutSection/types.ts
+++ b/src/components/molecules/AboutSection/types.ts
@@ -1,0 +1,4 @@
+export interface AboutSectionProps {
+  title: string
+  children: React.ReactNode
+}

--- a/src/components/molecules/DirectoryTree/index.tsx
+++ b/src/components/molecules/DirectoryTree/index.tsx
@@ -1,0 +1,70 @@
+import React, { useState } from 'react'
+import { DirectoryTreeProps, FileStructure } from './types'
+import { fileStructure } from '@/utils/constants/files'
+
+export const DirectoryTree: React.FC<DirectoryTreeProps> = ({
+  className = '',
+  currentFile,
+  onFileSelect,
+}) => {
+  const [expandedDirs, setExpandedDirs] = useState<Set<string>>(new Set(['/']))
+
+  const toggleDir = (path: string) => {
+    const newExpanded = new Set(expandedDirs)
+    if (newExpanded.has(path)) {
+      newExpanded.delete(path)
+    } else {
+      newExpanded.add(path)
+    }
+    setExpandedDirs(newExpanded)
+  }
+
+  const renderItem = (item: FileStructure, level: number = 0) => {
+    const isExpanded = expandedDirs.has(item.path)
+    const isCurrentFile = item.path === currentFile
+    const paddingLeft = `${level * 16}px`
+
+    if (item.type === 'file') {
+      return (
+        <div
+          key={item.path}
+          className={`
+            px-2 py-1 cursor-pointer hover:bg-[#44475a]/50
+            ${isCurrentFile ? 'bg-[#44475a] text-[#f8f8f2]' : 'text-[#6272a4]'}
+          `}
+          style={{ paddingLeft }}
+          onClick={() => onFileSelect(item.path)}
+        >
+          {item.icon} {item.name}
+        </div>
+      )
+    }
+
+    return (
+      <div key={item.path}>
+        <div
+          className="px-2 py-1 cursor-pointer hover:bg-[#44475a]/50 text-[#f8f8f2] flex items-center"
+          style={{ paddingLeft }}
+          onClick={() => toggleDir(item.path)}
+        >
+          <span className="mr-2">{isExpanded ? '▼' : '▶'}</span>
+          {item.name}
+        </div>
+        {isExpanded && item.children?.map(child => renderItem(child, level + 1))}
+      </div>
+    )
+  }
+
+  return (
+    <div
+      className={`w-[280px] bg-[#282a36]/90 backdrop-blur-md rounded-xl border border-[#6272a4]/30 shadow-xl font-mono ${className}`}
+    >
+      {/* エクスプローラーヘッダー */}
+      <div className="h-12 px-4 flex items-center text-[#f8f8f2] text-sm border-b border-[#6272a4]/30">
+        EXPLORER
+      </div>
+      {/* ディレクトリ構造 */}
+      <div className="p-2 text-sm">{fileStructure.map(item => renderItem(item))}</div>
+    </div>
+  )
+}

--- a/src/components/molecules/DirectoryTree/types.ts
+++ b/src/components/molecules/DirectoryTree/types.ts
@@ -1,0 +1,19 @@
+export interface DirectoryTreeProps {
+  className?: string
+  currentFile: string
+  onFileSelect: (path: string) => void
+}
+
+export interface FileStructure {
+  name: string
+  type: 'file' | 'directory'
+  path: string
+  children?: FileStructure[]
+  icon?: string
+}
+
+export interface FileContent {
+  path: string
+  content: string
+  language: string
+}

--- a/src/components/organisms/AboutMeContent/index.tsx
+++ b/src/components/organisms/AboutMeContent/index.tsx
@@ -1,55 +1,105 @@
 import React from 'react'
-import Avatar from '@/components/atoms/Avatar'
-import AboutSection from '@/components/molecules/AboutSection'
 import { AboutMeContentProps } from './types'
 
-const AboutMeContent: React.FC<AboutMeContentProps> = () => {
+const AboutMeContent: React.FC<AboutMeContentProps> = ({
+  currentFile,
+  openFiles,
+  fileContent,
+  onFileSelect,
+  onCloseFile,
+}) => {
+  if (!fileContent) return null
+
+  const lines = fileContent.content.split('\n')
+
   return (
-    <div className="max-w-4xl mx-auto p-8 bg-[#282a36] rounded-xl shadow-lg">
-      <div className="flex flex-col items-center mb-8">
-        <Avatar src="/profile.jpg" alt="プロフィール画像" size={120} />
-        <h1 className="mt-4 text-4xl font-bold text-[#f8f8f2]">[あなたの名前]</h1>
+    <div className="h-full flex flex-col">
+      {/* タブバー */}
+      <div className="h-10 bg-[#21222c] flex items-center border-b border-[#44475a]">
+        <div className="flex h-full">
+          {openFiles.map(path => {
+            const isActive = path === currentFile
+            const fileName = path.split('/').pop()
+
+            return (
+              <div
+                key={path}
+                onClick={() => onFileSelect(path)}
+                className={`
+                  h-full px-4 flex items-center gap-2 cursor-pointer group border-r border-[#44475a]
+                  ${isActive ? 'bg-[#282a36] text-[#f8f8f2]' : 'bg-[#21222c] text-[#6272a4] hover:bg-[#282a36]/50'}
+                `}
+              >
+                <span className="text-[#ff79c6]">ts</span>
+                <span>{fileName}</span>
+                <button
+                  onClick={e => {
+                    e.stopPropagation()
+                    onCloseFile(path)
+                  }}
+                  className="opacity-0 group-hover:opacity-100 hover:text-[#ff5555]"
+                >
+                  ×
+                </button>
+              </div>
+            )
+          })}
+        </div>
       </div>
-      <AboutSection title="自己紹介">
-        <p>
-          こんにちは、[あなたの名前]です。フルスタックエンジニアとして、最先端の技術を駆使し、ユーザーに最適な体験を提供することに情熱を注いでいます。
-        </p>
-      </AboutSection>
-      <AboutSection title="スキルと技術">
-        <ul className="list-disc list-inside">
-          <li>JavaScript / TypeScript</li>
-          <li>React / Next.js</li>
-          <li>Node.js / Express</li>
-          <li>HTML / CSS (Tailwind CSS)</li>
-        </ul>
-      </AboutSection>
-      <AboutSection title="経歴・実績">
-        <p>
-          これまでに[企業名]や[プロジェクト名]で数多くのプロジェクトに携わり、業界内で高い評価を受けてきました。
-        </p>
-      </AboutSection>
-      <AboutSection title="興味・趣味">
-        <p>プログラミング以外では、アウトドア活動や音楽鑑賞、読書などを楽しんでいます。</p>
-      </AboutSection>
-      <AboutSection title="連絡先情報">
-        <p>
-          Email:{' '}
-          <a href="mailto:example@example.com" className="text-[#50fa7b] underline">
-            example@example.com
-          </a>
-        </p>
-        <p>
-          LinkedIn:{' '}
-          <a
-            href="https://www.linkedin.com/in/your-linkedin"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-[#50fa7b] underline"
-          >
-            your-linkedin
-          </a>
-        </p>
-      </AboutSection>
+
+      {/* エディタ本体 */}
+      <div className="flex-1 overflow-auto">
+        <div className="flex">
+          {/* 行番号 */}
+          <div className="w-[50px] flex-shrink-0 bg-[#282a36] text-[#6272a4] text-right pr-4 select-none border-r border-[#44475a]">
+            {lines.map((_, i) => (
+              <div key={i} className="h-6 text-sm leading-6">
+                {String(i + 1).padStart(2, '0')}
+              </div>
+            ))}
+          </div>
+
+          {/* コード */}
+          <div className="flex-1 relative">
+            {/* インデントガイド */}
+            <div
+              className="absolute top-0 left-0 h-full w-px bg-[#44475a]/30"
+              style={{ left: '16px' }}
+            />
+            <div
+              className="absolute top-0 left-0 h-full w-px bg-[#44475a]/30"
+              style={{ left: '32px' }}
+            />
+
+            {/* コードコンテンツ */}
+            <pre className="p-0 m-0">
+              <code className="block px-4 text-[#f8f8f2] text-sm leading-6">
+                {lines.map((line, i) => (
+                  <div key={i} className="whitespace-pre">
+                    {line || '\n'}
+                  </div>
+                ))}
+              </code>
+            </pre>
+          </div>
+
+          {/* ミニマップ */}
+          <div className="w-[60px] flex-shrink-0 bg-[#282a36] border-l border-[#44475a]" />
+        </div>
+      </div>
+
+      {/* ステータスバー */}
+      <div className="h-6 bg-[#191a21] text-[#6272a4] flex items-center px-4 text-xs border-t border-[#44475a]">
+        <div className="flex items-center gap-4">
+          <span>{fileContent.language}</span>
+          <span>UTF-8</span>
+          <span>LF</span>
+          <span className="flex items-center gap-1">
+            <span className="w-2 h-2 rounded-full bg-[#50fa7b]" />
+            Prettier
+          </span>
+        </div>
+      </div>
     </div>
   )
 }

--- a/src/components/organisms/AboutMeContent/index.tsx
+++ b/src/components/organisms/AboutMeContent/index.tsx
@@ -1,0 +1,57 @@
+import React from 'react'
+import Avatar from '@/components/atoms/Avatar'
+import AboutSection from '@/components/molecules/AboutSection'
+import { AboutMeContentProps } from './types'
+
+const AboutMeContent: React.FC<AboutMeContentProps> = () => {
+  return (
+    <div className="max-w-4xl mx-auto p-8 bg-[#282a36] rounded-xl shadow-lg">
+      <div className="flex flex-col items-center mb-8">
+        <Avatar src="/profile.jpg" alt="プロフィール画像" size={120} />
+        <h1 className="mt-4 text-4xl font-bold text-[#f8f8f2]">[あなたの名前]</h1>
+      </div>
+      <AboutSection title="自己紹介">
+        <p>
+          こんにちは、[あなたの名前]です。フルスタックエンジニアとして、最先端の技術を駆使し、ユーザーに最適な体験を提供することに情熱を注いでいます。
+        </p>
+      </AboutSection>
+      <AboutSection title="スキルと技術">
+        <ul className="list-disc list-inside">
+          <li>JavaScript / TypeScript</li>
+          <li>React / Next.js</li>
+          <li>Node.js / Express</li>
+          <li>HTML / CSS (Tailwind CSS)</li>
+        </ul>
+      </AboutSection>
+      <AboutSection title="経歴・実績">
+        <p>
+          これまでに[企業名]や[プロジェクト名]で数多くのプロジェクトに携わり、業界内で高い評価を受けてきました。
+        </p>
+      </AboutSection>
+      <AboutSection title="興味・趣味">
+        <p>プログラミング以外では、アウトドア活動や音楽鑑賞、読書などを楽しんでいます。</p>
+      </AboutSection>
+      <AboutSection title="連絡先情報">
+        <p>
+          Email:{' '}
+          <a href="mailto:example@example.com" className="text-[#50fa7b] underline">
+            example@example.com
+          </a>
+        </p>
+        <p>
+          LinkedIn:{' '}
+          <a
+            href="https://www.linkedin.com/in/your-linkedin"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-[#50fa7b] underline"
+          >
+            your-linkedin
+          </a>
+        </p>
+      </AboutSection>
+    </div>
+  )
+}
+
+export default AboutMeContent

--- a/src/components/organisms/AboutMeContent/index.tsx
+++ b/src/components/organisms/AboutMeContent/index.tsx
@@ -27,7 +27,9 @@ const AboutMeContent: React.FC<AboutMeContentProps> = ({
                 onClick={() => onFileSelect(path)}
                 className={`
                   h-full px-4 flex items-center gap-2 cursor-pointer group border-r border-[#44475a]
+                  relative transition-colors duration-150
                   ${isActive ? 'bg-[#282a36] text-[#f8f8f2]' : 'bg-[#21222c] text-[#6272a4] hover:bg-[#282a36]/50'}
+                  ${isActive ? 'after:absolute after:bottom-0 after:left-0 after:w-full after:h-[2px] after:bg-[#ff79c6]' : ''}
                 `}
               >
                 <span className="text-[#ff79c6]">ts</span>
@@ -37,7 +39,7 @@ const AboutMeContent: React.FC<AboutMeContentProps> = ({
                     e.stopPropagation()
                     onCloseFile(path)
                   }}
-                  className="opacity-0 group-hover:opacity-100 hover:text-[#ff5555]"
+                  className="opacity-0 group-hover:opacity-100 hover:text-[#ff5555] transition-opacity"
                 >
                   ×
                 </button>

--- a/src/components/organisms/AboutMeContent/types.ts
+++ b/src/components/organisms/AboutMeContent/types.ts
@@ -1,0 +1,9 @@
+import { FileContent } from '@/components/molecules/DirectoryTree/types'
+
+export interface AboutMeContentProps {
+  currentFile: string
+  openFiles: string[]
+  fileContent: FileContent
+  onFileSelect: (path: string) => void
+  onCloseFile: (path: string) => void
+}

--- a/src/utils/constants/files.ts
+++ b/src/utils/constants/files.ts
@@ -1,0 +1,89 @@
+import { FileStructure, FileContent } from '@/components/molecules/DirectoryTree/types'
+
+export const fileStructure: FileStructure[] = [
+  {
+    name: 'portfolio-site',
+    type: 'directory',
+    path: '/',
+    children: [
+      {
+        name: 'src',
+        type: 'directory',
+        path: '/src',
+        children: [
+          {
+            name: 'about-me',
+            type: 'directory',
+            path: '/src/about-me',
+            children: [
+              {
+                name: 'introduction.ts',
+                type: 'file',
+                path: '/src/about-me/introduction.ts',
+                icon: '📄',
+              },
+              {
+                name: 'skills.ts',
+                type: 'file',
+                path: '/src/about-me/skills.ts',
+                icon: '📄',
+              },
+              {
+                name: 'experience.ts',
+                type: 'file',
+                path: '/src/about-me/experience.ts',
+                icon: '📄',
+              },
+              {
+                name: 'contact.ts',
+                type: 'file',
+                path: '/src/about-me/contact.ts',
+                icon: '📄',
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+]
+
+export const fileContents: Record<string, FileContent> = {
+  '/src/about-me/self-introduction.ts': {
+    path: '/src/about-me/self-introduction.ts',
+    language: 'typescript',
+    content: `const developer = "[あなたの名前]";
+  
+  function getIntroduction() {
+    return "フルスタックエンジニアとして、最先端の技術を駆使し、" +
+           "ユーザーに最適な体験を提供することに情熱を注いでいます。";
+  }
+  
+  export { developer, getIntroduction };`,
+  },
+  '/src/about-me/skills.ts': {
+    path: '/src/about-me/skills.ts',
+    language: 'typescript',
+    content: `const skills = {
+    frontend: [
+      "JavaScript",
+      "TypeScript",
+      "React",
+      "Next.js",
+      "HTML/CSS"
+    ],
+    backend: [
+      "Node.js",
+      "Express",
+      "Python",
+      "Django"
+    ],
+    database: [
+      "SQL",
+      "NoSQL"
+    ]
+  };
+  
+  export { skills };`,
+  },
+}

--- a/src/utils/constants/files.ts
+++ b/src/utils/constants/files.ts
@@ -49,41 +49,24 @@ export const fileStructure: FileStructure[] = [
 ]
 
 export const fileContents: Record<string, FileContent> = {
-  '/src/about-me/self-introduction.ts': {
-    path: '/src/about-me/self-introduction.ts',
+  '/src/about-me/introduction.ts': {
+    path: '/src/about-me/introduction.ts',
     language: 'typescript',
-    content: `const developer = "[あなたの名前]";
-  
-  function getIntroduction() {
-    return "フルスタックエンジニアとして、最先端の技術を駆使し、" +
-           "ユーザーに最適な体験を提供することに情熱を注いでいます。";
-  }
-  
-  export { developer, getIntroduction };`,
+    content: `const developer = "[あなたの名前]";`,
   },
   '/src/about-me/skills.ts': {
     path: '/src/about-me/skills.ts',
     language: 'typescript',
-    content: `const skills = {
-    frontend: [
-      "JavaScript",
-      "TypeScript",
-      "React",
-      "Next.js",
-      "HTML/CSS"
-    ],
-    backend: [
-      "Node.js",
-      "Express",
-      "Python",
-      "Django"
-    ],
-    database: [
-      "SQL",
-      "NoSQL"
-    ]
-  };
-  
-  export { skills };`,
+    content: `const skills = {}`,
+  },
+  '/src/about-me/experience.ts': {
+    path: '/src/about-me/experience.ts',
+    language: 'typescript',
+    content: `const experience = []`,
+  },
+  '/src/about-me/contact.ts': {
+    path: '/src/about-me/contact.ts',
+    language: 'typescript',
+    content: `const contact = {}`,
   },
 }

--- a/src/utils/constants/files.ts
+++ b/src/utils/constants/files.ts
@@ -17,28 +17,28 @@ export const fileStructure: FileStructure[] = [
             path: '/src/about-me',
             children: [
               {
-                name: 'introduction.ts',
+                name: 'introduction.ojx',
                 type: 'file',
-                path: '/src/about-me/introduction.ts',
-                icon: '📄',
+                path: '/src/about-me/introduction.ojx',
+                icon: '🎯',
               },
               {
-                name: 'skills.ts',
+                name: 'skills.ojx',
                 type: 'file',
-                path: '/src/about-me/skills.ts',
-                icon: '📄',
+                path: '/src/about-me/skills.ojx',
+                icon: '⚡',
               },
               {
-                name: 'experience.ts',
+                name: 'experience.ojx',
                 type: 'file',
-                path: '/src/about-me/experience.ts',
-                icon: '📄',
+                path: '/src/about-me/experience.ojx',
+                icon: '🚀',
               },
               {
-                name: 'contact.ts',
+                name: 'contact.ojx',
                 type: 'file',
-                path: '/src/about-me/contact.ts',
-                icon: '📄',
+                path: '/src/about-me/contact.ojx',
+                icon: '💫',
               },
             ],
           },
@@ -49,24 +49,24 @@ export const fileStructure: FileStructure[] = [
 ]
 
 export const fileContents: Record<string, FileContent> = {
-  '/src/about-me/introduction.ts': {
-    path: '/src/about-me/introduction.ts',
-    language: 'typescript',
+  '/src/about-me/introduction.ojx': {
+    path: '/src/about-me/introduction.ojx',
+    language: 'javascript',
     content: `const developer = "[あなたの名前]";`,
   },
-  '/src/about-me/skills.ts': {
-    path: '/src/about-me/skills.ts',
-    language: 'typescript',
+  '/src/about-me/skills.ojx': {
+    path: '/src/about-me/skills.ojx',
+    language: 'javascript',
     content: `const skills = {}`,
   },
-  '/src/about-me/experience.ts': {
-    path: '/src/about-me/experience.ts',
-    language: 'typescript',
+  '/src/about-me/experience.ojx': {
+    path: '/src/about-me/experience.ojx',
+    language: 'javascript',
     content: `const experience = []`,
   },
-  '/src/about-me/contact.ts': {
-    path: '/src/about-me/contact.ts',
-    language: 'typescript',
+  '/src/about-me/contact.ojx': {
+    path: '/src/about-me/contact.ojx',
+    language: 'javascript',
     content: `const contact = {}`,
   },
 }

--- a/src/utils/constants/navigation.ts
+++ b/src/utils/constants/navigation.ts
@@ -4,7 +4,7 @@ export const routes = [
     label: '_home',
   },
   {
-    path: '/about',
+    path: '/about-me',
     label: '_about-me',
   },
   {


### PR DESCRIPTION
## 🔄 変更内容

コードエディタライクなUIを持つAbout Meページの実装

## 🎯 関連 Issue

- close #14

## ✨ 変更点

### コンポーネントの追加
- Avatarコンポーネントとその型定義を追加
- AboutSectionコンポーネントとその型定義を追加
- AboutMeContentコンポーネントとその型定義を追加
- DirectoryTreeコンポーネントとその型定義を追加

### UI/UXの改善
- VSCodeライクなエディタUIを実装
  - ファイルエクスプローラー
  - タブ管理システム
  - エディタ本体（行番号、インデントガイド）
- ドラキュラテーマを適用
- カスタム拡張子(.ojx)の導入
- ナビゲーションバーの統合

### リファクタリング
- AboutMeContentをエディタスタイルに完全リファクタリング
- ファイル構成の簡素化
- タブスタイルの強化（アクティブ状態とトランジション）

## 📸 スクリーンショット

<!-- UI変更のスクリーンショットを添付 -->

## ✅ 確認項目

- [ ] 

## 🔍 テスト項目

- [x] ファイルエクスプローラーの展開/折りたたみが正常に動作する
- [x] タブの切り替えが正しく機能する
- [x] ファイルの開閉が適切に動作する
- [x] すべてのページで正しくナビゲーションバーが表示される

## 📝 補足情報
