### PR TITLE
refactor/#17: AboutMeContentコンポーネントをコンポーネント分割

### DIFF
--- a/src/app/about-me/page.tsx
+++ b/src/app/about-me/page.tsx
@@ -4,12 +4,14 @@ import React, { useState } from 'react'
 import AboutMeContent from '@/components/organisms/AboutMeContent'
 import { EditorLayout } from '@/components/templates/EditorLayout'
 import { DirectoryTree } from '@/components/molecules/DirectoryTree'
+import { ActivityBar } from '@/components/molecules/ActivityBar'
+import { EditorTitleBar } from '@/components/molecules/EditorTitleBar'
 import { fileContents } from '@/utils/constants/files'
 
 const AboutMePage: React.FC = () => {
   // 開いているファイルのパスを配列で管理
-  const [openFiles, setOpenFiles] = useState<string[]>(['/src/about-me/introduction.ts'])
-  const [currentFile, setCurrentFile] = useState('/src/about-me/introduction.ts')
+  const [openFiles, setOpenFiles] = useState<string[]>(['/src/about-me/introduction.ojx'])
+  const [currentFile, setCurrentFile] = useState('/src/about-me/introduction.ojx')
 
   const handleFileSelect = (path: string) => {
     // 既に開いているファイルの場合は、そのファイルをアクティブにする
@@ -31,45 +33,12 @@ const AboutMePage: React.FC = () => {
   return (
     <EditorLayout>
       <div className="min-h-[calc(100vh-48px)] w-full flex items-center justify-center bg-[#282a36]">
-        <div className="w-[1300px] h-[700px] bg-[#282a36] rounded-xl border border-[#6272a4]/30 shadow-2xl overflow-hidden backdrop-blur-sm">
-          {/* タイトルバー */}
-          <div className="h-10 bg-[#21222c] flex items-center px-4 gap-2 border-b border-[#44475a]">
-            <div className="flex items-center gap-2">
-              <div className="w-3 h-3 rounded-full bg-[#ff5555] hover:bg-[#ff6e6e] transition-colors" />
-              <div className="w-3 h-3 rounded-full bg-[#f1fa8c] hover:bg-[#f4fb9d] transition-colors" />
-              <div className="w-3 h-3 rounded-full bg-[#50fa7b] hover:bg-[#6dff93] transition-colors" />
-            </div>
-            <div className="flex-1 text-center text-[#6272a4] text-sm">
-              about-me - Ojoxux Editor
-            </div>
-          </div>
+        <div className="w-[1600px] h-[700px] bg-[#282a36] rounded-xl border border-[#6272a4]/30 shadow-2xl overflow-hidden backdrop-blur-sm">
+          <EditorTitleBar title="about-me - VS Code" />
 
           <div className="h-[calc(100%-2.5rem)] flex">
-            {/* Activity Bar */}
-            <div className="w-12 bg-[#21222c] flex flex-col items-center py-4 space-y-4">
-              <button className="w-8 h-8 flex items-center justify-center text-[#bd93f9] hover:text-[#ff79c6] transition-colors">
-                <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M3 6h18M3 12h18M3 18h18"
-                  />
-                </svg>
-              </button>
-              <button className="w-8 h-8 flex items-center justify-center text-[#f8f8f2] bg-[#44475a] rounded">
-                <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"
-                  />
-                </svg>
-              </button>
-            </div>
+            <ActivityBar />
 
-            {/* Side Bar & Editor */}
             <div className="flex-1 flex">
               <DirectoryTree
                 currentFile={currentFile}

--- a/src/components/atoms/ActivityBarButton/index.tsx
+++ b/src/components/atoms/ActivityBarButton/index.tsx
@@ -1,0 +1,26 @@
+interface ActivityBarButtonProps {
+  icon: React.ReactNode
+  isActive?: boolean
+  onClick?: () => void
+}
+
+export const ActivityBarButton: React.FC<ActivityBarButtonProps> = ({
+  icon,
+  isActive,
+  onClick,
+}) => {
+  return (
+    <button
+      onClick={onClick}
+      className={`
+          w-8 h-8 flex items-center justify-center
+          transition-colors
+          ${
+            isActive ? 'text-[#f8f8f2] bg-[#44475a] rounded' : 'text-[#bd93f9] hover:text-[#ff79c6]'
+          }
+        `}
+    >
+      {icon}
+    </button>
+  )
+}

--- a/src/components/atoms/ActivityBarButton/index.tsx
+++ b/src/components/atoms/ActivityBarButton/index.tsx
@@ -1,8 +1,4 @@
-interface ActivityBarButtonProps {
-  icon: React.ReactNode
-  isActive?: boolean
-  onClick?: () => void
-}
+import { ActivityBarButtonProps } from './types'
 
 export const ActivityBarButton: React.FC<ActivityBarButtonProps> = ({
   icon,

--- a/src/components/atoms/ActivityBarButton/types.ts
+++ b/src/components/atoms/ActivityBarButton/types.ts
@@ -1,0 +1,5 @@
+export interface ActivityBarButtonProps {
+  icon: React.ReactNode
+  isActive?: boolean
+  onClick?: () => void
+}

--- a/src/components/atoms/EditorTab/index.tsx
+++ b/src/components/atoms/EditorTab/index.tsx
@@ -1,10 +1,4 @@
-interface EditorTabProps {
-  fileName: string
-  isActive: boolean
-  extension: string
-  onSelect: () => void
-  onClose: (e: React.MouseEvent) => void
-}
+import { EditorTabProps } from './types'
 
 export const EditorTab: React.FC<EditorTabProps> = ({
   fileName,

--- a/src/components/atoms/EditorTab/index.tsx
+++ b/src/components/atoms/EditorTab/index.tsx
@@ -1,0 +1,36 @@
+interface EditorTabProps {
+  fileName: string
+  isActive: boolean
+  extension: string
+  onSelect: () => void
+  onClose: (e: React.MouseEvent) => void
+}
+
+export const EditorTab: React.FC<EditorTabProps> = ({
+  fileName,
+  isActive,
+  extension,
+  onSelect,
+  onClose,
+}) => {
+  return (
+    <div
+      onClick={onSelect}
+      className={`
+          h-full px-4 flex items-center gap-2 cursor-pointer group border-r border-[#44475a]
+          relative transition-colors duration-150
+          ${isActive ? 'bg-[#282a36] text-[#f8f8f2]' : 'bg-[#21222c] text-[#6272a4] hover:bg-[#282a36]/50'}
+          ${isActive ? 'after:absolute after:bottom-0 after:left-0 after:w-full after:h-[2px] after:bg-[#ff79c6]' : ''}
+        `}
+    >
+      <span className="text-[#ff79c6]">{extension}</span>
+      <span>{fileName}</span>
+      <button
+        onClick={onClose}
+        className="opacity-0 group-hover:opacity-100 hover:text-[#ff5555] transition-opacity"
+      >
+        ×
+      </button>
+    </div>
+  )
+}

--- a/src/components/atoms/EditorTab/types.ts
+++ b/src/components/atoms/EditorTab/types.ts
@@ -1,0 +1,7 @@
+export interface EditorTabProps {
+  fileName: string
+  isActive: boolean
+  extension: string
+  onSelect: () => void
+  onClose: (e: React.MouseEvent) => void
+}

--- a/src/components/atoms/EditorWindowControl/index.tsx
+++ b/src/components/atoms/EditorWindowControl/index.tsx
@@ -1,0 +1,28 @@
+interface EditorWindowControlProps {
+  onClose?: () => void
+  onMinimize?: () => void
+  onMaximize?: () => void
+}
+
+export const EditorWindowControl: React.FC<EditorWindowControlProps> = ({
+  onClose,
+  onMinimize,
+  onMaximize,
+}) => {
+  return (
+    <div className="flex items-center gap-2">
+      <div
+        onClick={onClose}
+        className="w-3 h-3 rounded-full bg-[#ff5555] hover:bg-[#ff6e6e] transition-colors cursor-pointer"
+      />
+      <div
+        onClick={onMinimize}
+        className="w-3 h-3 rounded-full bg-[#f1fa8c] hover:bg-[#f4fb9d] transition-colors cursor-pointer"
+      />
+      <div
+        onClick={onMaximize}
+        className="w-3 h-3 rounded-full bg-[#50fa7b] hover:bg-[#6dff93] transition-colors cursor-pointer"
+      />
+    </div>
+  )
+}

--- a/src/components/atoms/EditorWindowControl/index.tsx
+++ b/src/components/atoms/EditorWindowControl/index.tsx
@@ -1,8 +1,4 @@
-interface EditorWindowControlProps {
-  onClose?: () => void
-  onMinimize?: () => void
-  onMaximize?: () => void
-}
+import { EditorWindowControlProps } from './types'
 
 export const EditorWindowControl: React.FC<EditorWindowControlProps> = ({
   onClose,

--- a/src/components/atoms/EditorWindowControl/types.ts
+++ b/src/components/atoms/EditorWindowControl/types.ts
@@ -1,0 +1,5 @@
+export interface EditorWindowControlProps {
+  onClose?: () => void
+  onMinimize?: () => void
+  onMaximize?: () => void
+}

--- a/src/components/atoms/LineNumber/index.tsx
+++ b/src/components/atoms/LineNumber/index.tsx
@@ -1,0 +1,7 @@
+interface LineNumberProps {
+  number: number
+}
+
+export const LineNumber: React.FC<LineNumberProps> = ({ number }) => (
+  <div className="h-6 text-sm leading-6">{String(number).padStart(2, '0')}</div>
+)

--- a/src/components/atoms/LineNumber/index.tsx
+++ b/src/components/atoms/LineNumber/index.tsx
@@ -1,6 +1,4 @@
-interface LineNumberProps {
-  number: number
-}
+import { LineNumberProps } from './types'
 
 export const LineNumber: React.FC<LineNumberProps> = ({ number }) => (
   <div className="h-6 text-sm leading-6">{String(number).padStart(2, '0')}</div>

--- a/src/components/atoms/LineNumber/types.ts
+++ b/src/components/atoms/LineNumber/types.ts
@@ -1,0 +1,3 @@
+export interface LineNumberProps {
+  number: number
+}

--- a/src/components/molecules/ActivityBar/index.tsx
+++ b/src/components/molecules/ActivityBar/index.tsx
@@ -1,0 +1,33 @@
+import { ActivityBarButton } from '@/components/atoms/ActivityBarButton'
+
+export const ActivityBar: React.FC = () => {
+  return (
+    <div className="w-12 bg-[#21222c] flex flex-col items-center py-4 space-y-4">
+      <ActivityBarButton
+        icon={
+          <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M3 6h18M3 12h18M3 18h18"
+            />
+          </svg>
+        }
+      />
+      <ActivityBarButton
+        isActive
+        icon={
+          <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"
+            />
+          </svg>
+        }
+      />
+    </div>
+  )
+}

--- a/src/components/molecules/EditorContent/index.tsx
+++ b/src/components/molecules/EditorContent/index.tsx
@@ -1,0 +1,24 @@
+interface EditorContentProps {
+  content: string[]
+}
+
+export const EditorContent: React.FC<EditorContentProps> = ({ content }) => {
+  return (
+    <div className="flex-1 relative">
+      {/* インデントガイド */}
+      <div className="absolute top-0 left-0 h-full w-px bg-[#44475a]/30" style={{ left: '16px' }} />
+      <div className="absolute top-0 left-0 h-full w-px bg-[#44475a]/30" style={{ left: '32px' }} />
+
+      {/* コードコンテンツ */}
+      <pre className="p-0 m-0">
+        <code className="block px-4 text-[#f8f8f2] text-sm leading-6">
+          {content.map((line, i) => (
+            <div key={i} className="whitespace-pre">
+              {line || '\n'}
+            </div>
+          ))}
+        </code>
+      </pre>
+    </div>
+  )
+}

--- a/src/components/molecules/EditorContent/index.tsx
+++ b/src/components/molecules/EditorContent/index.tsx
@@ -1,6 +1,4 @@
-interface EditorContentProps {
-  content: string[]
-}
+import { EditorContentProps } from './types'
 
 export const EditorContent: React.FC<EditorContentProps> = ({ content }) => {
   return (

--- a/src/components/molecules/EditorContent/types.ts
+++ b/src/components/molecules/EditorContent/types.ts
@@ -1,0 +1,3 @@
+export interface EditorContentProps {
+  content: string[]
+}

--- a/src/components/molecules/EditorTabs/index.tsx
+++ b/src/components/molecules/EditorTabs/index.tsx
@@ -1,0 +1,41 @@
+import { EditorTab } from '@/components/atoms/EditorTab'
+
+interface EditorTabsProps {
+  openFiles: string[]
+  currentFile: string
+  onFileSelect: (path: string) => void
+  onCloseFile: (path: string) => void
+}
+
+export const EditorTabs: React.FC<EditorTabsProps> = ({
+  openFiles,
+  currentFile,
+  onFileSelect,
+  onCloseFile,
+}) => {
+  return (
+    <div className="h-10 bg-[#21222c] flex items-center border-b border-[#44475a]">
+      <div className="flex h-full">
+        {openFiles.map(path => {
+          const isActive = path === currentFile
+          const fileName = path.split('/').pop()
+          const extension = 'ojx'
+
+          return (
+            <EditorTab
+              key={path}
+              fileName={fileName || ''}
+              extension={extension}
+              isActive={isActive}
+              onSelect={() => onFileSelect(path)}
+              onClose={e => {
+                e.stopPropagation()
+                onCloseFile(path)
+              }}
+            />
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/src/components/molecules/EditorTabs/index.tsx
+++ b/src/components/molecules/EditorTabs/index.tsx
@@ -1,11 +1,5 @@
 import { EditorTab } from '@/components/atoms/EditorTab'
-
-interface EditorTabsProps {
-  openFiles: string[]
-  currentFile: string
-  onFileSelect: (path: string) => void
-  onCloseFile: (path: string) => void
-}
+import { EditorTabsProps } from './types'
 
 export const EditorTabs: React.FC<EditorTabsProps> = ({
   openFiles,

--- a/src/components/molecules/EditorTabs/types.ts
+++ b/src/components/molecules/EditorTabs/types.ts
@@ -1,0 +1,6 @@
+export interface EditorTabsProps {
+  openFiles: string[]
+  currentFile: string
+  onFileSelect: (path: string) => void
+  onCloseFile: (path: string) => void
+}

--- a/src/components/molecules/EditorTitleBar/index.tsx
+++ b/src/components/molecules/EditorTitleBar/index.tsx
@@ -1,8 +1,5 @@
 import { EditorWindowControl } from '@/components/atoms/EditorWindowControl'
-
-interface EditorTitleBarProps {
-  title: string
-}
+import { EditorTitleBarProps } from './types'
 
 export const EditorTitleBar: React.FC<EditorTitleBarProps> = ({ title }) => {
   return (

--- a/src/components/molecules/EditorTitleBar/index.tsx
+++ b/src/components/molecules/EditorTitleBar/index.tsx
@@ -1,0 +1,14 @@
+import { EditorWindowControl } from '@/components/atoms/EditorWindowControl'
+
+interface EditorTitleBarProps {
+  title: string
+}
+
+export const EditorTitleBar: React.FC<EditorTitleBarProps> = ({ title }) => {
+  return (
+    <div className="h-10 bg-[#21222c] flex items-center px-4 gap-2 border-b border-[#44475a]">
+      <EditorWindowControl />
+      <div className="flex-1 text-center text-[#6272a4] text-sm">{title}</div>
+    </div>
+  )
+}

--- a/src/components/molecules/EditorTitleBar/types.ts
+++ b/src/components/molecules/EditorTitleBar/types.ts
@@ -1,0 +1,3 @@
+export interface EditorTitleBarProps {
+  title: string
+}

--- a/src/components/molecules/StatusBar/index.tsx
+++ b/src/components/molecules/StatusBar/index.tsx
@@ -1,7 +1,4 @@
-interface StatusBarProps {
-  language: string
-}
-
+import { StatusBarProps } from './types'
 export const StatusBar: React.FC<StatusBarProps> = ({ language }) => {
   return (
     <div className="h-6 bg-[#191a21] text-[#6272a4] flex items-center px-4 text-xs border-t border-[#44475a]">

--- a/src/components/molecules/StatusBar/index.tsx
+++ b/src/components/molecules/StatusBar/index.tsx
@@ -1,0 +1,19 @@
+interface StatusBarProps {
+  language: string
+}
+
+export const StatusBar: React.FC<StatusBarProps> = ({ language }) => {
+  return (
+    <div className="h-6 bg-[#191a21] text-[#6272a4] flex items-center px-4 text-xs border-t border-[#44475a]">
+      <div className="flex items-center gap-4">
+        <span>{language}</span>
+        <span>UTF-8</span>
+        <span>LF</span>
+        <span className="flex items-center gap-1">
+          <span className="w-2 h-2 rounded-full bg-[#50fa7b]" />
+          Prettier
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/src/components/molecules/StatusBar/types.ts
+++ b/src/components/molecules/StatusBar/types.ts
@@ -1,0 +1,3 @@
+export interface StatusBarProps {
+  language: string
+}

--- a/src/components/organisms/AboutMeContent/index.tsx
+++ b/src/components/organisms/AboutMeContent/index.tsx
@@ -1,4 +1,8 @@
 import React from 'react'
+import { EditorTabs } from '@/components/molecules/EditorTabs'
+import { EditorContent } from '@/components/molecules/EditorContent'
+import { LineNumber } from '@/components/atoms/LineNumber'
+import { StatusBar } from '@/components/molecules/StatusBar'
 import { AboutMeContentProps } from './types'
 
 const AboutMeContent: React.FC<AboutMeContentProps> = ({
@@ -14,94 +18,30 @@ const AboutMeContent: React.FC<AboutMeContentProps> = ({
 
   return (
     <div className="h-full flex flex-col">
-      {/* タブバー */}
-      <div className="h-10 bg-[#21222c] flex items-center border-b border-[#44475a]">
-        <div className="flex h-full">
-          {openFiles.map(path => {
-            const isActive = path === currentFile
-            const fileName = path.split('/').pop()
+      <EditorTabs
+        openFiles={openFiles}
+        currentFile={currentFile}
+        onFileSelect={onFileSelect}
+        onCloseFile={onCloseFile}
+      />
 
-            return (
-              <div
-                key={path}
-                onClick={() => onFileSelect(path)}
-                className={`
-                  h-full px-4 flex items-center gap-2 cursor-pointer group border-r border-[#44475a]
-                  relative transition-colors duration-150
-                  ${isActive ? 'bg-[#282a36] text-[#f8f8f2]' : 'bg-[#21222c] text-[#6272a4] hover:bg-[#282a36]/50'}
-                  ${isActive ? 'after:absolute after:bottom-0 after:left-0 after:w-full after:h-[2px] after:bg-[#ff79c6]' : ''}
-                `}
-              >
-                <span className="text-[#ff79c6]">ts</span>
-                <span>{fileName}</span>
-                <button
-                  onClick={e => {
-                    e.stopPropagation()
-                    onCloseFile(path)
-                  }}
-                  className="opacity-0 group-hover:opacity-100 hover:text-[#ff5555] transition-opacity"
-                >
-                  ×
-                </button>
-              </div>
-            )
-          })}
-        </div>
-      </div>
-
-      {/* エディタ本体 */}
       <div className="flex-1 overflow-auto">
         <div className="flex">
           {/* 行番号 */}
           <div className="w-[50px] flex-shrink-0 bg-[#282a36] text-[#6272a4] text-right pr-4 select-none border-r border-[#44475a]">
             {lines.map((_, i) => (
-              <div key={i} className="h-6 text-sm leading-6">
-                {String(i + 1).padStart(2, '0')}
-              </div>
+              <LineNumber key={i} number={i + 1} />
             ))}
           </div>
 
-          {/* コード */}
-          <div className="flex-1 relative">
-            {/* インデントガイド */}
-            <div
-              className="absolute top-0 left-0 h-full w-px bg-[#44475a]/30"
-              style={{ left: '16px' }}
-            />
-            <div
-              className="absolute top-0 left-0 h-full w-px bg-[#44475a]/30"
-              style={{ left: '32px' }}
-            />
-
-            {/* コードコンテンツ */}
-            <pre className="p-0 m-0">
-              <code className="block px-4 text-[#f8f8f2] text-sm leading-6">
-                {lines.map((line, i) => (
-                  <div key={i} className="whitespace-pre">
-                    {line || '\n'}
-                  </div>
-                ))}
-              </code>
-            </pre>
-          </div>
+          <EditorContent content={lines} />
 
           {/* ミニマップ */}
           <div className="w-[60px] flex-shrink-0 bg-[#282a36] border-l border-[#44475a]" />
         </div>
       </div>
 
-      {/* ステータスバー */}
-      <div className="h-6 bg-[#191a21] text-[#6272a4] flex items-center px-4 text-xs border-t border-[#44475a]">
-        <div className="flex items-center gap-4">
-          <span>{fileContent.language}</span>
-          <span>UTF-8</span>
-          <span>LF</span>
-          <span className="flex items-center gap-1">
-            <span className="w-2 h-2 rounded-full bg-[#50fa7b]" />
-            Prettier
-          </span>
-        </div>
-      </div>
+      <StatusBar language={fileContent.language} />
     </div>
   )
 }


### PR DESCRIPTION
## 🔄 変更内容

AboutMeページのコンポーネントをAtomicDesignパターンに基づいて再構築

## 🎯 関連 Issue

- close #17 

## ✨ 変更点

### Atomsコンポーネントの追加
- EditorWindowControl: ウィンドウコントロールボタン（閉じる、最小化、最大化）
- EditorTab: 単一のエディタタブ
- ActivityBarButton: アクティビティバーの各ボタン
- LineNumber: エディタの行番号表示

### Moleculesコンポーネントの追加
- EditorTitleBar: ウィンドウ上部のタイトルバー
- ActivityBar: 左側のアクティビティメニュー
- EditorContent: エディタのメインコンテンツ領域
- EditorTabs: 複数のエディタタブを管理
- StatusBar: エディタ下部のステータス表示

### リファクタリング
- AboutMeContentコンポーネントを複数の小さなコンポーネントに分割
- AboutMePageのレイアウト構造を整理
- コンポーネント間の責務を明確化

## 📸 スクリーンショット

<!-- UI変更のスクリーンショットを添付 -->

## ✅ 確認項目

- [x] コンポーネントの分割が適切に行われている
- [x] 各コンポーネントの型定義が適切
- [x] コンポーネント間の依存関係が明確

## 🔍 テスト項目

- [x] 各Atomsコンポーネントが独立して機能する
- [x] Moleculesコンポーネントが正しく子コンポーネントを統合している
- [x] タブの切り替えが正常に動作する
- [x] ウィンドウコントロールの見た目が適切
- [x] アクティビティバーのボタンが正しく表示される
- [x] エディタの行番号が正しく表示される
- [x] ステータスバーの情報が正確に表示される

## 📝 補足情報