### PR TITLE
fix/#45: 🛠️ コンポーネントツリーに'use client'ディレクティブを追加

### DIFF
--- a/src/components/templates/EditorLayout/index.tsx
+++ b/src/components/templates/EditorLayout/index.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { EditorNav } from '@/components/organisms/EditorNav'
 import { BottomNav } from '@/components/organisms/BottomNav'
 import { EditorLayoutProps } from './types'


### PR DESCRIPTION
## 🔄 変更内容

Server ComponentからClient Componentへのイベントハンドラーの受け渡しエラーを修正

## 🎯 関連 Issue

- close #45

## ✨ 変更点

- `src/components/templates/EditorLayout/index.tsx`に'use client'ディレクティブを追加

## 📸 スクリーンショット

<!-- エラーが解消されたことを示すスクリーンショットを添付 -->

## ✅ 確認項目

- [x] コンフリクトがない

## 🔍 テスト項目

- [x] SNSリンクのクリックが正常に動作することを確認
- [x] GitHubリンクが新しいタブで開くことを確認
- [x] Instagramリンクが新しいタブで開くことを確認
- [x] コンソールにエラーが表示されないことを確認

## 📝 補足情報

Next.js 13+におけるServer ComponentとClient Componentの適切な使い分けに関する修正です。
インタラクティブな機能を持つコンポーネントを適切にClient Componentとして実装することで、
イベントハンドラーの受け渡しに関するエラーを解消しています。